### PR TITLE
Correct URL for Pull Requests

### DIFF
--- a/src/js/components/notification.js
+++ b/src/js/components/notification.js
@@ -18,7 +18,7 @@ var Notification = React.createClass({
   openBrowser: function () {
     var url = this.props.notification.subject.url.replace('api.github.com/repos', 'www.github.com');
     if (url.indexOf("/pulls/") != -1) {
-      url = url.replace("/pulls/", "/pull/")
+      url = url.replace("/pulls/", "/pull/");
     }
     shell.openExternal(url);
   },

--- a/src/js/components/notification.js
+++ b/src/js/components/notification.js
@@ -17,6 +17,9 @@ var Notification = React.createClass({
 
   openBrowser: function () {
     var url = this.props.notification.subject.url.replace('api.github.com/repos', 'www.github.com');
+    if (url.indexOf("/pulls/") != -1) {
+      url = url.replace("/pulls/", "/pull/")
+    }
     shell.openExternal(url);
   },
 


### PR DESCRIPTION
Pull Request notifications had the URL: `https://www.github.com/atom/find-and-replace/pulls/399`

Which would link to an author. This PR corrects it to be: `https://www.github.com/atom/find-and-replace/pull/399`

I only had one notification to test it with though.