### PR TITLE
Make visible menu window on all workspaces

### DIFF
--- a/main.js
+++ b/main.js
@@ -42,6 +42,7 @@ app.on('ready', function(){
     appIcon.window = new BrowserWindow(defaults);
     appIcon.window.loadUrl('file://' + __dirname + '/index.html');
     appIcon.window.on('blur', hideWindow);
+    appIcon.window.setVisibleOnAllWorkspaces(true);
 
     initMenu();
   }


### PR DESCRIPTION
Hi.
Thank you for such a great app.

In OS X, gitify is now bound to specific work space where gitify firstly started.  When I click the menu icon in other workspace, the window will be opened in the bound work space and current workspace is forced to be changed.

I used `BrowserWindow.setVisibleOnAllWorkspaces()` API to solve this issue.

https://github.com/atom/electron/blob/master/docs/api/browser-window.md#browserwindowsetvisibleonallworkspacesvisible

I think all menu bar applications should set this option to true.