### PR TITLE
Smaller font size for repos names

### DIFF
--- a/src/less/style.less
+++ b/src/less/style.less
@@ -377,7 +377,7 @@ input {
 /* @group Component / Repository  */
 
 .repository {
-  padding: 10px 20px;
+  padding: 5px 20px;
   margin: 0;
   background-color: @LightGray;
   .ReadMixin();
@@ -389,15 +389,16 @@ input {
 
   .avatar {
     .BorderRadius(50%);
-    width: 25px;
-    height: 25px;
+    width: 23px;
+    height: 23px;
+    margin-top: 5px;
   }
 
   .name {
     .FontOpenSansSemibold();
-    font-size: 18px;
+    font-size: 16px;
     text-align: right;
-    padding: 0 5px;
+    padding: 5px;
 
     span {
       display: inline-block;
@@ -410,7 +411,7 @@ input {
   }
 
   .check-wrapper {
-    padding: 0 5px;
+    padding: 4px 5px;
 
     .octicon {
       font-size: 22px;


### PR DESCRIPTION
Closes #140.

![screen shot 2015-12-11 at 20 10 42](https://cloud.githubusercontent.com/assets/6333409/11754431/509a23a4-a043-11e5-8af1-6a47da29bfec.png)
