### PR TITLE
#207 - Click on notification(1) goes straight to GitHub

### DIFF
--- a/src/js/components/notification.js
+++ b/src/js/components/notification.js
@@ -4,6 +4,8 @@ import React from 'react';
 import { connect } from 'react-redux';
 
 import { markNotification } from '../actions';
+import Helpers from '../utils/helpers';
+
 
 export class SingleNotification extends React.Component {
 
@@ -16,10 +18,7 @@ export class SingleNotification extends React.Component {
   }
 
   openBrowser() {
-    var url = this.props.notification.subject.url.replace('api.github.com/repos', 'www.github.com');
-    if (url.indexOf('/pulls/') !== -1) {
-      url = url.replace('/pulls/', '/pull/');
-    }
+    var url = Helpers.generateGitHubUrl(this.props.notification.subject.url);
     shell.openExternal(url);
   }
 

--- a/src/js/utils/helpers.js
+++ b/src/js/utils/helpers.js
@@ -7,5 +7,13 @@ export default {
     } else {
       ipcRenderer.send('update-icon', 'TrayIdle');
     }
+  },
+
+  generateGitHubUrl(url) {
+    var newUrl = url.replace('api.github.com/repos', 'www.github.com');
+    if (newUrl.indexOf('/pulls/') !== -1) {
+      newUrl = newUrl.replace('/pulls/', '/pull/');
+    }
+    return newUrl;
   }
 };

--- a/src/js/utils/notifications.js
+++ b/src/js/utils/notifications.js
@@ -1,4 +1,7 @@
 const ipcRenderer = window.require('electron').ipcRenderer;
+const shell = window.require('electron').shell;
+
+import Helpers from '../utils/helpers';
 
 export default {
   setup(notifications, settings) {
@@ -46,7 +49,12 @@ export default {
     });
 
     nativeNotification.onclick = function () {
-      ipcRenderer.send('reopen-window');
+      if (newCount === 1) {
+        var url = Helpers.generateGitHubUrl(notifications[0].subject.url);
+        shell.openExternal(url);
+      } else {
+        ipcRenderer.send('reopen-window');
+      }
     };
 
     return nativeNotification;


### PR DESCRIPTION
Closed #207 .

On click of a native notification, if there is only 1 notification, it will go straight to the browser. If there are multiple, it will open Gitify.